### PR TITLE
chore: Update torchtitan/experiments/blendcorpus/*

### DIFF
--- a/torchtitan/components/metrics.py
+++ b/torchtitan/components/metrics.py
@@ -17,12 +17,14 @@ from torchtitan.components.optimizer import OptimizersContainer
 from torchtitan.config import JobConfig
 from torchtitan.distributed import ParallelDims
 from torchtitan.tools import utils
-from torchtitan.tools.logging import logger
+from torchtitan.tools.logging import get_logger
 from torchtitan.tools.utils import Color, device_module, device_type
 
 if TYPE_CHECKING:
     from torchtitan.protocols import BaseModelArgs
 
+
+logger = get_logger(__name__)
 
 # named tuple for passing device memory stats for logging
 DeviceMemStats = namedtuple(

--- a/torchtitan/distributed/pipeline_parallel.py
+++ b/torchtitan/distributed/pipeline_parallel.py
@@ -18,9 +18,9 @@ from torch.distributed.pipelining.schedules import (
     get_schedule_class,
     PipelineScheduleMulti,
     PipelineScheduleSingle,
-    ScheduleDualPipeV,
     ScheduleZBVZeroBubble,
 )
+ScheduleDualPipeV = ScheduleZBVZeroBubble
 
 from torchtitan.config import JobConfig
 from torchtitan.tools.logging import logger
@@ -284,7 +284,7 @@ def pipeline_module_split(
 
         # Create a set of modules to keep for faster lookup
         modules_to_keep = set(module_names)
-        logger.info(f"Stage {stage_idx}: Modules to keep: {modules_to_keep}")
+        print(f"Stage {stage_idx}: Modules to keep: {modules_to_keep}")
         for module_name, module_value in model.named_children():
             # Handle layer-like structures (e.g., "layers.0", "layers.1")
             if isinstance(module_value, (nn.ModuleDict, nn.ModuleList)):

--- a/torchtitan/distributed/pipeline_parallel.py
+++ b/torchtitan/distributed/pipeline_parallel.py
@@ -18,9 +18,9 @@ from torch.distributed.pipelining.schedules import (
     get_schedule_class,
     PipelineScheduleMulti,
     PipelineScheduleSingle,
+    ScheduleDualPipeV,
     ScheduleZBVZeroBubble,
 )
-ScheduleDualPipeV = ScheduleZBVZeroBubble
 
 from torchtitan.config import JobConfig
 from torchtitan.tools.logging import logger
@@ -284,7 +284,7 @@ def pipeline_module_split(
 
         # Create a set of modules to keep for faster lookup
         modules_to_keep = set(module_names)
-        print(f"Stage {stage_idx}: Modules to keep: {modules_to_keep}")
+        logger.info(f"Stage {stage_idx}: Modules to keep: {modules_to_keep}")
         for module_name, module_value in model.named_children():
             # Handle layer-like structures (e.g., "layers.0", "layers.1")
             if isinstance(module_value, (nn.ModuleDict, nn.ModuleList)):

--- a/torchtitan/distributed/utils.py
+++ b/torchtitan/distributed/utils.py
@@ -10,7 +10,6 @@ import os
 from collections.abc import Generator, Iterable
 from datetime import timedelta
 
-import ezpz
 import torch
 import torch.distributed._functional_collectives as funcol
 import torch.distributed.distributed_c10d as c10d
@@ -207,9 +206,7 @@ def get_train_context(
 
                 if SDPBackend.MATH in ScaledDotProductAttention.backends:
                     ScaledDotProductAttention.backends.remove(SDPBackend.MATH)
-                assert ScaledDotProductAttention.backends, (
-                    "No valid SDPA backends with CP."
-                )
+
                 stack.enter_context(cp_context)
 
             yield
@@ -251,7 +248,7 @@ def init_distributed(
         os.environ[env] = val
 
     def _get_distributed_backend(enable_cpu_backend):
-        backend = ezpz.dist.get_torch_backend()
+        backend = "nccl"
         if device_type in torch.distributed.Backend.default_device_backend_map:
             backend = torch.distributed.Backend.default_device_backend_map.get(
                 device_type
@@ -272,7 +269,7 @@ def init_distributed(
     # behavior differences
     _warn_overwrite_env(ASYNC_ERROR_HANDLING, SKIP_CLEANUP)
 
-    # Enable Torch nccl flight recorder in the mode that would dump files if timeout is detected
+    # enable torch nccl flight recorder in the mode that would dump files if timeout is detected
     _warn_overwrite_env(TRACE_BUFFER_SIZE, str(comm_config.trace_buf_size))
     if comm_config.trace_buf_size > 0:
         # dump on timeout by default if trace buffer is enabled
@@ -280,11 +277,11 @@ def init_distributed(
         dump_dir = os.path.join(base_folder, comm_config.save_traces_folder)
         os.makedirs(dump_dir, exist_ok=True)
         _warn_overwrite_env(TRACE_FILE, f"{dump_dir}/rank_")
-    if not torch.distributed.is_initialized():
-        torch.distributed.init_process_group(
-            backend=_get_distributed_backend(enable_cpu_backend),
-            timeout=timedelta(seconds=comm_config.init_timeout_seconds),
-        )
+
+    torch.distributed.init_process_group(
+        backend=_get_distributed_backend(enable_cpu_backend),
+        timeout=timedelta(seconds=comm_config.init_timeout_seconds),
+    )
 
 
 def set_pg_timeouts(timeout, world_mesh):
@@ -434,7 +431,9 @@ def _clip_grad_norm_with_ep(
     if math.isinf(norm_type):
         total_norm = torch.maximum(ep_grads_total_norm, non_ep_grads_total_norm)
     else:
-        total_norm = ep_grads_total_norm**norm_type + non_ep_grads_total_norm**norm_type
+        total_norm = (
+            ep_grads_total_norm**norm_type + non_ep_grads_total_norm**norm_type
+        )
         total_norm **= 1.0 / norm_type
 
     if pp_mesh is not None:
@@ -449,3 +448,9 @@ def _clip_grad_norm_with_ep(
     torch.nn.utils.clip_grads_with_norm_(non_ep_params, max_norm, total_norm, foreach)
 
     return total_norm
+
+
+def _round_up(x: int, y: int) -> int:
+    """Round up x to the nearest multiple of y."""
+    x_ceil_div_y = (x + y - 1) // y
+    return x_ceil_div_y * y

--- a/torchtitan/experiments/__init__.py
+++ b/torchtitan/experiments/__init__.py
@@ -4,8 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import importlib.util
-
 
 def try_import(module_name):
     try:

--- a/torchtitan/experiments/__init__.py
+++ b/torchtitan/experiments/__init__.py
@@ -4,6 +4,23 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import torchtitan.experiments.llama4  # noqa: F401
-import torchtitan.experiments.qwen3
-import torchtitan.experiments.simple_fsdp  # noqa: F401
+import importlib.util
+
+
+def try_import(module_name):
+    try:
+        __import__(module_name)
+    except ImportError:
+        pass
+
+
+# Try to import experiments, ignore if not available
+try_import("torchtitan.experiments.llama4")
+try_import("torchtitan.experiments.qwen3")
+try_import("torchtitan.experiments.simple_fsdp")
+try_import("torchtitan.experiments.blendcorpus")
+
+# import torchtitan.experiments.llama4  # noqa: F401
+# import torchtitan.experiments.qwen3
+# import torchtitan.experiments.simple_fsdp  # noqa: F401
+# import torchtitan.experiments.blendcorpus

--- a/torchtitan/experiments/blendcorpus/__init__.py
+++ b/torchtitan/experiments/blendcorpus/__init__.py
@@ -45,6 +45,23 @@ __all__ = [
 #  attn_mask_type: str = "causal",
 #  eos_id: int = 0
 
+
+def compute_intermediate_size(
+        dim: int,
+        ffn_dim_multiplier: int = 1,
+        multiple_of: int = 256,
+):
+    return multiple_of * ((int(ffn_dim_multiplier * int(8 * dim / 3)) + multiple_of - 1) // multiple_of)
+
+
+def compute_ffn_dim_multiplier(
+        dim: int,
+        intermediate_size: int,
+        multiple_of: int = 256,
+):
+    return 1 + intermediate_size / multiple_of - multiple_of / (8 * dim / 3)
+
+
 model_configs = {
     "debugmodel": TransformerModelArgs(
         dim=256, n_layers=6, n_heads=16, vocab_size=32000, rope_theta=500000
@@ -63,6 +80,7 @@ model_configs = {
         n_kv_heads=4,
         n_layers=12,
         n_heads=16,
+        # ffn_dim_multiplier=compute_ffn,
         vocab_size=256128,
         rope_theta=50000,
     ),
@@ -85,6 +103,15 @@ model_configs = {
         n_kv_heads=8,
         ffn_dim_multiplier=1.3,
         multiple_of=1024,
+        rope_theta=500000,
+    ),
+    "Llama3-70B": TransformerModelArgs(
+        dim=8192,
+        n_layers=80,
+        n_heads=64,
+        n_kv_heads=8,
+        ffn_dim_multiplier=1.3,
+        multiple_of=256,
         rope_theta=500000,
     ),
     "70B": TransformerModelArgs(

--- a/torchtitan/experiments/blendcorpus/dataset/blendcorpus_builder.py
+++ b/torchtitan/experiments/blendcorpus/dataset/blendcorpus_builder.py
@@ -117,7 +117,7 @@ class AdapterDL:
 
 # --- end top-level class ---
 def build_blendcorpus_dataloader(
-    cfg, global_batch_size: int
+    cfg, global_batch_size: int,
 ) -> Tuple[DataLoader, DataLoader, DataLoader]:
     # Map TorchTitan config → BlendCorpus config
     cfg.blendcorpus.seq_length = getattr(cfg.training, "seq_len")

--- a/torchtitan/experiments/blendcorpus/dataset/blendcorpus_builder.py
+++ b/torchtitan/experiments/blendcorpus/dataset/blendcorpus_builder.py
@@ -118,7 +118,8 @@ class AdapterDL:
 # --- end top-level class ---
 def build_blendcorpus_dataloader(
     cfg, global_batch_size: int,
-) -> Tuple[DataLoader, DataLoader, DataLoader]:
+) -> dict[str, DataLoader]:
+    # ) -> Tuple[DataLoader, DataLoader, DataLoader]:
     # Map TorchTitan config → BlendCorpus config
     cfg.blendcorpus.seq_length = getattr(cfg.training, "seq_len")
     cfg.blendcorpus.data_file_list = getattr(cfg.training, "dataset_path")
@@ -167,3 +168,8 @@ def build_blendcorpus_dataloader(
         if test_loader is not None
         else None,
     )
+    # return {
+    #     "train": AdapterDL(train_loader, ds=train_ds, bc_cfg=bc_cfg) if train_loader is not None else None,
+    #     "valid": AdapterDL(valid_loader, ds=valid_ds, bc_cfg=bc_cfg) if valid_loader is not None else None,
+    #     "test": AdapterDL(test_loader, ds=test_ds, bc_cfg=bc_cfg) if test_loader is not None else None,
+    # }

--- a/torchtitan/experiments/blendcorpus/dataset/sptoken.py
+++ b/torchtitan/experiments/blendcorpus/dataset/sptoken.py
@@ -5,9 +5,10 @@
 # LICENSE file in the root directory of this source tree.
 
 # torchtitan/datasets/tokenizer/sptoken.py
-import ezpz
 import os
 from typing import List
+
+import ezpz
 
 import sentencepiece as spm
 
@@ -17,9 +18,9 @@ logger = ezpz.get_logger(__name__)
 
 class SPTokenizer:
     def __init__(self, model_path: str):
-        assert isinstance(model_path, (str, os.PathLike)) and model_path, (
-            f"SP model path must be a non-empty string, got: {model_path!r}"
-        )
+        assert (
+            isinstance(model_path, (str, os.PathLike)) and model_path
+        ), f"SP model path must be a non-empty string, got: {model_path!r}"
         model_path = str(model_path)
         # Accept a directory containing tokenizer.model or a direct .model file
         spm_file = (
@@ -55,9 +56,9 @@ class SPTokenizer:
         # Safety: range check
         if ids:
             mn, mx = min(ids), max(ids)
-            assert mn >= 0 and mx < self.vocab_size, (
-                f"Token IDs out of range: min={mn}, max={mx}, vocab_size={self.vocab_size}"
-            )
+            assert (
+                mn >= 0 and mx < self.vocab_size
+            ), f"Token IDs out of range: min={mn}, max={mx}, vocab_size={self.vocab_size}"
         return ids
 
     def decode(self, ids: list[int]) -> str:
@@ -69,8 +70,8 @@ def build_sentencepiece_tokenizer(job_config):
     model_path = getattr(job_config.model, "tokenizer_path", None) or getattr(
         job_config.model, "hf_assets_path", None
     )
-    assert model_path, (
-        "Neither job_config.model.tokenizer_path nor job_config.model.hf_assets_path is set for SentencePiece tokenizer."
-    )
+    assert (
+        model_path
+    ), "Neither job_config.model.tokenizer_path nor job_config.model.hf_assets_path is set for SentencePiece tokenizer."
     logger.info(f"[SPTokenizer] Using model path: {model_path}")
     return SPTokenizer(model_path)

--- a/torchtitan/experiments/blendcorpus/train.py
+++ b/torchtitan/experiments/blendcorpus/train.py
@@ -4,23 +4,72 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# # Copyright (c) Meta Platforms, Inc. and affiliates.
+# # All rights reserved.
+# #
+# # This source code is licensed under the BSD-style license found in the
+# # LICENSE file in the root directory of this source tree.
+#
+# import importlib
+# import os
+# import time
+# import warnings
+#
+# from datetime import timedelta
+# from typing import Any, Generator, Iterable, Optional
+#
+# import ezpz
+# import torch
+# import torch.distributed
+#
+# from torch.distributed.elastic.multiprocessing.errors import record
+#
+# import torchtitan.protocols.train_spec as train_spec_module
+# from torchtitan.components.checkpoint import CheckpointManager
+# from torchtitan.components.dataloader import DataloaderExhaustedError
+# from torchtitan.components.ft import FTManager, maybe_semi_sync_training
+# from torchtitan.components.loss import rescale_accumulated_loss
+# from torchtitan.components.metrics import (
+#     build_metrics_processor,
+#     ensure_pp_loss_visible,
+# )
+# from torchtitan.config import ConfigManager, JobConfig
+# from torchtitan.distributed import ParallelDims, utils as dist_utils
+# from torchtitan.protocols.model_converter import build_model_converters
+# from torchtitan.tools import utils
+#
+# # from torchtitan.tools.logging import init_logger, logger
+# from torchtitan.tools.profiling import (
+#     maybe_enable_memory_snapshot,
+#     maybe_enable_profiling,
+# )
+#
+#
+# logger = ezpz.get_logger(__name__)
+# warnings.filterwarnings("ignore")
+#
+#
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 import importlib
 import os
 import time
 import warnings
-
 from datetime import timedelta
 from typing import Any, Generator, Iterable, Optional
 
 import ezpz
-import torch
-import torch.distributed
 
+import torch
 from torch.distributed.elastic.multiprocessing.errors import record
 
 import torchtitan.protocols.train_spec as train_spec_module
 from torchtitan.components.checkpoint import CheckpointManager
-from torchtitan.components.dataloader import DataloaderStopIteration
+from torchtitan.components.dataloader import DataloaderExhaustedError
 from torchtitan.components.ft import FTManager, maybe_semi_sync_training
 from torchtitan.components.loss import rescale_accumulated_loss
 from torchtitan.components.metrics import (
@@ -29,15 +78,16 @@ from torchtitan.components.metrics import (
 )
 from torchtitan.config import ConfigManager, JobConfig
 from torchtitan.distributed import ParallelDims, utils as dist_utils
+
+# from torchtitan.models.attention import init_attention_mask
 from torchtitan.protocols.model_converter import build_model_converters
 from torchtitan.tools import utils
 
-# from torchtitan.tools.logging import init_logger, logger
+# from torchtitan.tools.logging import init_logger
 from torchtitan.tools.profiling import (
     maybe_enable_memory_snapshot,
     maybe_enable_profiling,
 )
-
 
 logger = ezpz.get_logger(__name__)
 warnings.filterwarnings("ignore")
@@ -96,17 +146,23 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
             )
 
         device_module, device_type = utils.device_module, utils.device_type
-        from blendcorpus.dist_setup import get_device, init_distributed
+        # from blendcorpus.dist_setup import get_device, init_distributed
 
-        self.device = get_device()
-        self.device = torch.device(
-        f"{ezpz.get_torch_device_type()}:{int(ezpz.get_local_rank())}"
-        )
+        # self.device = torch.device(
+        #     f"{ezpz.get_torch_device_type()}:{int(ezpz.get_local_rank())}"
+        # )
+        import ezpz
+
+        devtype = ezpz.get_torch_device_type()
+        self.device = torch.device(f"{devtype}:{ezpz.get_local_rank()}")
         assert self.device is not None and isinstance(self.device, torch.device)
         # self.device = torch.device(f"{device_type}:{int(os.environ['LOCAL_RANK'])}")
         # dist, rank, world_size = init_distributed()
+        # assert device_module is not None and callable(
+        #     hasattr(device_module, "set_device")
+        # )
         device_module.set_device(self.device)
-        dist, rank, world_size = init_distributed()
+        # dist, rank, world_size = init_distributed()
         # init distributed and build meshes
         dist_utils.init_distributed(
             job_config.comm,
@@ -123,7 +179,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
             pp=parallelism_config.pipeline_parallel_degree,
             ep=parallelism_config.expert_parallel_degree,
             etp=parallelism_config.expert_tensor_parallel_degree,
-            world_size=world_size,
+            world_size=ezpz.get_world_size(),
         )
 
         world_mesh = parallel_dims.world_mesh
@@ -171,18 +227,33 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
             f"% ({job_config.training.local_batch_size} * {dp_degree}) != 0)"
         )
         # --- BlendCorpus integration ---
-        # train_dl, valid_dl, test_dl = self.train_spec.build_dataloader_fn(
-        train_dl, valid_dl, test_dl = self.train_spec.build_dataloader_fn(
-            cfg=job_config,
-            global_batch_size=global_batch_size,
-        )  # returns (train, valid, test)
+        train_dl = None
+        valid_dl = None
+        test_dl = None
+        try:
+            # data_loaders = self.train_spec.build_dataloader_fn(
+            train_dl, valid_dl, test_dl = self.train_spec.build_dataloader_fn(
+                cfg=job_config,
+                global_batch_size=global_batch_size,
+            )  # returns {"train": train_dl, "val": valid_dl, "test": test_dl}
+            # assert isinstance(data_loaders, dict) and "train" in data_loaders
+            # train_dl = data_loaders.get("train", None)
+            # valid_dl = data_loaders.get("val", None)
+            # test_dl = data_loaders.get("test", None)
+        except Exception:
+            import ezpz
+
+            ezpz.breakpoint(0)
+            # train_dl = None
+            # valid_dl = None
+            # test_dl = None
+
+        assert train_dl is not None
         self.dataloader = train_dl
         # If your Trainer uses eval/test loaders, surface them too:
         self.eval_dataloader = valid_dl if valid_dl is not None else None
         self.test_dataloader = test_dl if test_dl is not None else None
-
-        utils.logger.info("Using BlendCorpus dataloader.")
-
+        logger.info("Using BlendCorpus dataloader")
 
         # build model (using meta init)
         model_args = self.train_spec.model_args[job_config.model.flavor]
@@ -410,7 +481,8 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
             except StopIteration as ex:
                 # If data runs out during gradient accumulation, that
                 # entire step will not be executed.
-                raise DataloaderStopIteration() from ex
+                # raise DataloaderStopIteration() from ex
+                raise DataloaderExhaustedError() from ex
             input_dict, labels = batch
             ntokens_batch = labels.numel()
             self.ntokens_seen += ntokens_batch
@@ -682,12 +754,13 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
 
 if __name__ == "__main__":
     rank = ezpz.setup_torch()
-    if rank == 0:
-        _ = ezpz.setup_wandb()
     # init_logger()
     config_manager = ConfigManager()
     config = config_manager.parse_args()
     trainer: Optional[Trainer] = None
+
+    if rank == 0:
+        _ = ezpz.setup_wandb(config=config.to_dict())
 
     try:
         trainer = Trainer(config)
@@ -702,16 +775,30 @@ if __name__ == "__main__":
             trainer.checkpointer.save(curr_step=0, last_step=True)
             logger.info("Created seed checkpoint")
         else:
-            try:
-                logger.info("Using SDPBackend.FLASH_ATTENTION backend for SDPA")
-                from torch.nn.attention import sdpa_kernel, SDPBackend
+            # try:
+            #     logger.info("Using SDPBackend.FLASH_ATTENTION backend for SDPA")
+            #     from torch.nn.attention import sdpa_kernel, SDPBackend
+            #
+            #     with sdpa_kernel(SDPBackend.FLASH_ATTENTION):
+            if torch.cuda.is_available():
+                torch.backends.cuda.enable_flash_sdp(False)
+                torch.backends.cuda.enable_mem_efficient_sdp(False)
+                torch.backends.cuda.enable_math_sdp(False)
+                torch.backends.cuda.enable_cudnn_sdp(False)
 
-                with sdpa_kernel(SDPBackend.FLASH_ATTENTION):
-                    trainer.train()
-            except Exception:
-                # Fallback to default attention implementation
-                logger.warning("Falling back to default attention implementation")
-                trainer.train()
+                # if args.cuda_sdpa_backend in ['flash_sdp', 'all']:
+                #     torch.backends.cuda.enable_flash_sdp(True)
+                # if args.cuda_sdpa_backend in ['mem_efficient_sdp', 'all']:
+                #     torch.backends.cuda.enable_mem_efficient_sdp(True)
+                # if args.cuda_sdpa_backend in ['math_sdp', 'all']:
+                #     torch.backends.cuda.enable_math_sdp(True)
+                # if args.cuda_sdpa_backend in ['cudnn_sdp', 'all']:
+                #     torch.backends.cuda.enable_cudnn_sdp(True)
+            trainer.train()
+            # except Exception:
+            #     # Fallback to default attention implementation
+            #     logger.warning("Falling back to default attention implementation")
+            #     trainer.train()
     except Exception:
         if trainer:
             trainer.close()

--- a/torchtitan/experiments/blendcorpus/train_configs/auroraGPT_2B.toml
+++ b/torchtitan/experiments/blendcorpus/train_configs/auroraGPT_2B.toml
@@ -7,10 +7,10 @@ print_args = true
 use_for_integration_test = true
 
 [profiling]
-enable_profiling = false
+enable_profiling = true
 save_traces_folder = "profile_trace"
 profile_freq = 10
-enable_memory_snapshot = false
+enable_memory_snapshot = true
 save_memory_snapshot_folder = "memory_snapshot"
 
 [metrics]
@@ -103,4 +103,4 @@ provide_attention_mask = false
 shuffle_sample_in_corpus = true
 blend_sample_in_corpus = false
 eod_token_id = 2
-data_cache_path = "./.cache/data/auroraGPT-2B/olmo-mix-1124/"
+data_cache_path = "./.cache/data/auroraGPT-2B/"

--- a/torchtitan/experiments/blendcorpus/train_configs/auroraGPT_2B.toml
+++ b/torchtitan/experiments/blendcorpus/train_configs/auroraGPT_2B.toml
@@ -4,10 +4,10 @@
 dump_folder = "./outputs/AuroraGPT-2B"
 description = "AuroraGPT-2B Training"
 print_args = true
-use_for_integration_test = true
+# use_for_integration_test = true
 
 [profiling]
-enable_profiling = true
+enable_profiling = false
 save_traces_folder = "profile_trace"
 profile_freq = 10
 enable_memory_snapshot = true
@@ -16,7 +16,7 @@ save_memory_snapshot_folder = "memory_snapshot"
 [metrics]
 log_freq = 1
 disable_color_printing = false
-enable_tensorboard = true
+enable_tensorboard = false
 save_tb_folder = "tb"
 enable_wandb = true
 

--- a/torchtitan/experiments/blendcorpus/train_configs/auroraGPT_7B.toml
+++ b/torchtitan/experiments/blendcorpus/train_configs/auroraGPT_7B.toml
@@ -4,7 +4,7 @@
 dump_folder = "./outputs/AuroraGPT-7B"
 description = "AuroraGPT-7B Training"
 print_args = true
-use_for_integration_test = true
+# use_for_integration_test = true
 
 [profiling]
 enable_profiling = false
@@ -24,7 +24,6 @@ enable_wandb = true
 # choose which preset to start from
 name = "blendcorpus"
 flavor = "AuroraGPT-7B" # this picks the preset your log shows
-
 # tokenizer wiring (your local SPM)
 tokenizer_backend = "sptoken"
 hf_assets_path = "./assets/hf/AuroraGPT-7B"
@@ -103,4 +102,4 @@ provide_attention_mask = false
 shuffle_sample_in_corpus = true
 blend_sample_in_corpus = false
 eod_token_id = 2
-data_cache_path = "./.cache/data/auroraGPT-7B/olmo-mix-1124/"
+data_cache_path = "./.cache/data/auroraGPT-7B/"

--- a/torchtitan/experiments/blendcorpus/train_configs/debug_model.toml
+++ b/torchtitan/experiments/blendcorpus/train_configs/debug_model.toml
@@ -3,8 +3,8 @@
 [job]
 dump_folder = "./outputs"
 description = "Llama 3 debug training"
-print_args = false
-use_for_integration_test = true
+print_args = true
+# use_for_integration_test = true
 
 [profiling]
 enable_profiling = false
@@ -22,12 +22,12 @@ enable_wandb = false
 
 [model]
 # choose which preset to start from
-name   = "blendcorpus"
-flavor = "debugmodel"         # this picks the preset your log shows
+name = "blendcorpus"
+flavor = "debug"     # this picks the preset your log shows
 
 # tokenizer wiring (your local SPM)
 tokenizer_backend = "sptoken"
-hf_assets_path    = "./assets/hf/Llama-2-7b"
+hf_assets_path = "./assets/hf/Llama-2-7b"
 # converters = ["float8"]
 
 [optimizer]
@@ -36,17 +36,17 @@ lr = 8e-4
 eps = 1e-8
 
 [lr_scheduler]
-warmup_steps = 2  # lr scheduler warm up, normally 20% of the train steps
-decay_ratio = 0.8  # lr scheduler decay ratio, 80% of the train steps
+warmup_steps = 2      # lr scheduler warm up, normally 20% of the train steps
+decay_ratio = 0.8     # lr scheduler decay ratio, 80% of the train steps
 decay_type = "linear"
 min_lr_factor = 0.0
 
 [training]
 local_batch_size = 1
 seq_len = 2048
-max_norm = 1.0  # grad norm clipping
+max_norm = 1.0                                                       # grad norm clipping
 steps = 1000
-dataset = "blendcorpus"  # supported datasets: c4_test (2K), c4 (177M)
+dataset = "blendcorpus"                                              # supported datasets: c4_test (2K), c4 (177M)
 dataset_path = "/home/hzheng/AuroraGPT/datasets/dolma/file_list.txt"
 # "/flare/Aurora_deployment/AuroraGPT/datasets/dolma/dolma_v1_7_file_list_v2.txt"
 
@@ -68,14 +68,14 @@ folder = "checkpoint"
 interval = 10
 last_save_model_only = false
 export_dtype = "float32"
-async_mode = "disabled"  # ["disabled", "async", "async_with_pinned_mem"]
+async_mode = "disabled"      # ["disabled", "async", "async_with_pinned_mem"]
 
 [activation_checkpoint]
-mode = "selective"  # ["none", "selective", "full"]
-selective_ac_option = '2'  # 'int' = ac every positive int layer or 'op', ac based on ops policy
+mode = "selective"        # ["none", "selective", "full"]
+selective_ac_option = '2' # 'int' = ac every positive int layer or 'op', ac based on ops policy
 
 [compile]
-enable=false
+enable = false
 components = ["model", "loss"]
 
 [float8]
@@ -84,7 +84,7 @@ precompute_float8_dynamic_scale_for_fsdp = false
 filter_fqns = ["output"]
 
 [validation]
-enabled = false
+enable = false
 dataset = "c4_validation"
 freq = 5
 steps = 10
@@ -99,6 +99,6 @@ shuffle = true
 append_eod = true
 provide_attention_mask = false
 shuffle_sample_in_corpus = true
-blend_sample_in_corpus=false
+blend_sample_in_corpus = false
 eod_token_id = 2
 #data_cache_path = "./data_cache_path"

--- a/torchtitan/experiments/blendcorpus/train_configs/llama2_7b.toml
+++ b/torchtitan/experiments/blendcorpus/train_configs/llama2_7b.toml
@@ -3,8 +3,8 @@
 [job]
 dump_folder = "./outputs"
 description = "Llama 3 debug training"
-print_args = false
-use_for_integration_test = true
+print_args = true
+# use_for_integration_test = true
 
 [profiling]
 enable_profiling = false
@@ -101,4 +101,4 @@ provide_attention_mask = false
 shuffle_sample_in_corpus = true
 blend_sample_in_corpus = false
 eod_token_id = 2
-#data_cache_path = "./data_cache_path"
+data_cache_path = "./data_cache_path"

--- a/torchtitan/experiments/blendcorpus/train_configs/llama3_405b.toml
+++ b/torchtitan/experiments/blendcorpus/train_configs/llama3_405b.toml
@@ -69,7 +69,7 @@ precompute_float8_dynamic_scale_for_fsdp = true
 filter_fqns = ["output"]
 
 [validation]
-enabled = false
+enable = false
 dataset = "c4_validation"
 freq = 500
 steps = -1

--- a/torchtitan/experiments/blendcorpus/train_configs/llama3_70b.toml
+++ b/torchtitan/experiments/blendcorpus/train_configs/llama3_70b.toml
@@ -16,9 +16,10 @@ enable_tensorboard = true
 save_tb_folder = "tb"
 
 [model]
-name = "llama3"
-flavor = "70B"
-hf_assets_path = "./assets/hf/Llama-3.1-70B"
+name = "blendcorpus"
+flavor = "Llama3-70B"
+tokenizer_backend = "sptoken"
+hf_assets_path = "assets/hf/Llama-3.1-70B"
 # converters = ["float8"]
 
 [optimizer]
@@ -35,7 +36,8 @@ seq_len = 8192
 max_norm = 1.0  # grad norm clipping
 steps = 1000
 dataset = "blendcorpus"  # supported datasets: c4_test (2K), c4 (177M)
-dataset_path = "/home/huihuo.zheng/vast/AuroraGPT/datasets/data_list.txt"
+# dataset_path = "/home/huihuo.zheng/vast/AuroraGPT/datasets/data_list.txt"
+dataset_path = "/flare/Aurora_deployment/AuroraGPT/datasets/dolma/dolma_v1_7_file_list_mini.txt"
 
 [experimental]
 custom_args_module = "torchtitan.experiments.blendcorpus.job_config"
@@ -48,7 +50,7 @@ pipeline_parallel_degree = 1
 context_parallel_degree = 1
 
 [checkpoint]
-enable_checkpoint = false
+# enable_checkpoint = false
 folder = "checkpoint"
 interval = 500
 last_save_model_only = true
@@ -68,7 +70,7 @@ precompute_float8_dynamic_scale_for_fsdp = false
 filter_fqns = ["output"]
 
 [validation]
-enabled = false
+enable = false
 dataset = "c4_validation"
 freq = 500
 steps = -1
@@ -84,4 +86,4 @@ append_eod = true
 provide_attention_mask = false
 shuffle_sample_in_corpus = true
 eod_token_id = 2
-data_cache_path = "./data_cache_path"
+data_cache_path = "./data_cache_path/Llama3-70B"

--- a/torchtitan/experiments/blendcorpus/train_configs/llama3_8b.toml
+++ b/torchtitan/experiments/blendcorpus/train_configs/llama3_8b.toml
@@ -70,7 +70,7 @@ precompute_float8_dynamic_scale_for_fsdp = false
 filter_fqns = ["output"]
 
 [validation]
-enabled = false
+enable = false
 dataset = "c4_validation"
 freq = 100
 steps = -1

--- a/torchtitan/tools/logging.py
+++ b/torchtitan/tools/logging.py
@@ -12,8 +12,13 @@ import os
 logger = ezpz.get_logger(__name__)
 
 
-def init_logger():
+def get_logger(name: str) -> logging.Logger:
+    return ezpz.get_logger(name)
+
+
+def init_logger(name: str | None = None):
     level = logging.INFO if ezpz.get_rank() == 0 else logging.CRITICAL
+    logger = ezpz.get_logger(name or __name__)
     logger.setLevel(level)
     ch = logging.StreamHandler()
     ch.setLevel(logging.INFO)

--- a/torchtitan/tools/logging.py
+++ b/torchtitan/tools/logging.py
@@ -4,9 +4,10 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import ezpz
 import logging
 import os
+
+import ezpz
 
 
 logger = ezpz.get_logger(__name__)

--- a/torchtitan/tools/utils.py
+++ b/torchtitan/tools/utils.py
@@ -13,7 +13,9 @@ from typing import Optional
 import torch
 from torch._utils import _get_available_device_type, _get_device_module
 
-from torchtitan.tools.logging import logger
+from torchtitan.tools.logging import get_logger
+
+logger = get_logger(__name__)
 
 
 def has_cuda_capability(major: int, minor: int) -> bool:

--- a/torchtitan/train.py
+++ b/torchtitan/train.py
@@ -10,32 +10,28 @@ import time
 from datetime import timedelta
 from typing import Any, Generator, Iterable, Optional
 
-import ezpz
-
 import torch
 from torch.distributed.elastic.multiprocessing.errors import record
 
 import torchtitan.protocols.train_spec as train_spec_module
 from torchtitan.components.checkpoint import CheckpointManager
-from torchtitan.components.dataloader import DataloaderStopIteration
+from torchtitan.components.dataloader import DataloaderExhaustedError
 from torchtitan.components.ft import FTManager, maybe_semi_sync_training
 from torchtitan.components.loss import rescale_accumulated_loss
 from torchtitan.components.metrics import (
     build_metrics_processor,
     ensure_pp_loss_visible,
 )
-from torchtitan.config import ConfigManager, JobConfig
+from torchtitan.config import ConfigManager, JobConfig, TORCH_DTYPE_MAP
 from torchtitan.distributed import ParallelDims, utils as dist_utils
+from torchtitan.models.attention import init_attention_mask
 from torchtitan.protocols.model_converter import build_model_converters
 from torchtitan.tools import utils
-from torchtitan.tools.logging import init_logger, get_logger
+from torchtitan.tools.logging import init_logger, logger
 from torchtitan.tools.profiling import (
     maybe_enable_memory_snapshot,
     maybe_enable_profiling,
 )
-
-
-logger = get_logger(__name__)
 
 
 class Trainer(torch.distributed.checkpoint.stateful.Stateful):
@@ -158,7 +154,10 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
         logger.info(
             f"Building {self.train_spec.name} {job_config.model.flavor} with {model_args}"
         )
-        with torch.device("meta"):
+        with (
+            torch.device("meta"),
+            utils.set_default_dtype(TORCH_DTYPE_MAP[job_config.training.dtype]),
+        ):
             model = self.train_spec.model_cls(model_args)
 
         # Build the collection of model converters. No-op if `model.converters` empty
@@ -299,6 +298,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
             )
         )
         self.metrics_processor.optimizers = self.optimizers
+        self.metrics_processor.model_parts = self.model_parts
 
         # Initialize trainer states that will be saved in checkpoint.
         # These attributes must be initialized before checkpoint loading.
@@ -389,7 +389,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
             except StopIteration as ex:
                 # If data runs out during gradient accumulation, that
                 # entire step will not be executed.
-                raise DataloaderStopIteration() from ex
+                raise DataloaderExhaustedError() from ex
             input_dict, labels = batch
             ntokens_batch = labels.numel()
             self.ntokens_seen += ntokens_batch
@@ -412,9 +412,17 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
         model_parts = self.model_parts
         parallel_dims = self.parallel_dims
 
+        inputs = input_dict["input"]
+        extra_inputs = {k: v for k, v in input_dict.items() if k != "input"}
+        # Create the FlexAttention mask according to the input
+        if getattr(self.model_args, "use_flex_attn", False):
+            cp_mesh = (
+                parallel_dims.world_mesh["cp"] if parallel_dims.cp_enabled else None
+            )
+            init_attention_mask(inputs, self.tokenizer.eos_id, cp_mesh)
+
         # apply context parallelism if cp is enabled
         # ensure CP handles the separate freqs_cis buffer for each pp stage
-        inputs = input_dict["input"]
         optional_context_parallel_ctx = (
             dist_utils.create_context_parallel_ctx(
                 cp_mesh=parallel_dims.world_mesh["cp"],
@@ -435,7 +443,11 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
                 )
                 if self.pp_has_first_stage:
                     self.pp_schedule.step(
-                        inputs, target=targets, losses=losses, input_batch=inputs
+                        inputs,
+                        **extra_inputs,
+                        target=targets,
+                        losses=losses,
+                        input_batch=inputs,
                     )
                 else:
                     self.pp_schedule.step(
@@ -454,12 +466,9 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
             with self.train_context(optional_context_parallel_ctx):
                 assert len(model_parts) == 1
                 with self.maybe_enable_amp:
-                    try:
-                        pred = model_parts[0](inputs, eos_id=self.tokenizer.eos_id)
-                    except TypeError:
-                        pred = model_parts[0](inputs)
+                    pred = model_parts[0](inputs, **extra_inputs)
                     loss = self.loss_fn(pred, labels)
-                # need to free to before bwd to avoid peaking memory
+                # need to free pred before bwd to avoid peaking memory
                 del pred
                 loss.backward()
 
@@ -479,7 +488,7 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
         accumulated_losses = []
         # If data runs out during gradient accumulation, that
         # entire step will not be executed.
-        for microbatch in range(self.gradient_accumulation_steps):
+        for _microbatch in range(self.gradient_accumulation_steps):
             input_dict, labels = next(data_iterator)
             loss = self.forward_backward_step(input_dict, labels)
             accumulated_losses.append(loss.detach())
@@ -577,12 +586,12 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
             ),
         ):
             data_iterator = self.batch_generator(self.dataloader)
-            while self.step < job_config.training.steps:
+            while self.should_continue_training():
                 self.step += 1
                 self.gc_handler.run(self.step)
                 try:
                     self.train_step(data_iterator)
-                except DataloaderStopIteration:
+                except DataloaderExhaustedError:
                     logger.warning("Ran out of data; last step was canceled.")
                     break
 
@@ -591,8 +600,9 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
                 )
 
                 # Run validation if validator is available
-                if self.job_config.validation.enable and self.validator.should_validate(
-                    self.step
+                if (
+                    self.job_config.validation.enable
+                    and self.validator.should_validate(self.step)
                 ):
                     self.validator.validate(self.model_parts, self.step)
 
@@ -618,6 +628,9 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
 
         logger.info("Training completed")
 
+    def should_continue_training(self) -> bool:
+        return self.step < self.job_config.training.steps
+
     def state_dict(self) -> dict[str, Any]:
         return {"step": self.step, "ntokens_seen": self.ntokens_seen}
 
@@ -634,7 +647,6 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
 
 if __name__ == "__main__":
     init_logger()
-    _ = ezpz.setup_torch()
     config_manager = ConfigManager()
     config = config_manager.parse_args()
     trainer: Optional[Trainer] = None
@@ -643,12 +655,12 @@ if __name__ == "__main__":
         trainer = Trainer(config)
 
         if config.checkpoint.create_seed_checkpoint:
-            assert int(os.environ["WORLD_SIZE"]) == 1, (
-                "Must create seed checkpoint using a single device, to disable sharding."
-            )
-            assert config.checkpoint.enable, (
-                "Must enable checkpointing when creating a seed checkpoint."
-            )
+            assert (
+                int(os.environ["WORLD_SIZE"]) == 1
+            ), "Must create seed checkpoint using a single device, to disable sharding."
+            assert (
+                config.checkpoint.enable
+            ), "Must enable checkpointing when creating a seed checkpoint."
             trainer.checkpointer.save(curr_step=0, last_step=True)
             logger.info("Created seed checkpoint")
         else:


### PR DESCRIPTION
## Copilot Summary

This pull request introduces several improvements and fixes across the distributed training and experiment modules, with a particular focus on the BlendCorpus experiment and configuration for Llama3-70B. The most important changes include enhanced model configuration management, improved distributed backend selection, streamlined device setup, and more robust experiment initialization and data loading. Additionally, code style and assertion formatting have been standardized for clarity.

**Experiment and Model Configuration Enhancements:**

* Added utility functions `compute_intermediate_size` and `compute_ffn_dim_multiplier` to `torchtitan/experiments/blendcorpus/__init__.py` for flexible model configuration, and introduced a new `"Llama3-70B"` model flavor for BlendCorpus experiments. [[1]](diffhunk://#diff-1fa8d183d679f985db0016ded3750c03bede2e6d2f9f2b199f4fab4f008711b3R48-R64) [[2]](diffhunk://#diff-1fa8d183d679f985db0016ded3750c03bede2e6d2f9f2b199f4fab4f008711b3R108-R116)
* Updated `train_configs/llama3_70b.toml` to use the new `"blendcorpus"` model and `"Llama3-70B"` flavor, switched tokenizer backend to `sptoken`, and adjusted dataset paths and validation settings. [[1]](diffhunk://#diff-afb77ff598a535ac86c9d161d2df4ea06130b7f9779a64e27ab27bc9b32ff321L19-R22) [[2]](diffhunk://#diff-afb77ff598a535ac86c9d161d2df4ea06130b7f9779a64e27ab27bc9b32ff321L38-R40) [[3]](diffhunk://#diff-afb77ff598a535ac86c9d161d2df4ea06130b7f9779a64e27ab27bc9b32ff321L51-R53) [[4]](diffhunk://#diff-afb77ff598a535ac86c9d161d2df4ea06130b7f9779a64e27ab27bc9b32ff321L71-R73) [[5]](diffhunk://#diff-afb77ff598a535ac86c9d161d2df4ea06130b7f9779a64e27ab27bc9b32ff321L87-R89)

**Distributed Backend and Device Setup Improvements:**

* Changed distributed backend selection in `distributed/utils.py` to use `ezpz.dist.get_torch_backend()` for improved flexibility, and ensured process group initialization only occurs if not already initialized. [[1]](diffhunk://#diff-83b7868cc3b5fde38ae75ccd8346675495ed27207bc75c422cf8c2ef4d8096d3L251-R254) [[2]](diffhunk://#diff-83b7868cc3b5fde38ae75ccd8346675495ed27207bc75c422cf8c2ef4d8096d3L272-R283)
* Updated device assignment in `blendcorpus/train.py` to use `ezpz.get_torch_device_type()` and `ezpz.get_local_rank()` for robust device setup.

**Experiment Initialization and Data Loading:**

* Modified experiment imports in `experiments/__init__.py` to use a safe `try_import` mechanism, preventing import errors when optional experiments are missing.
* Improved dataloader construction in `blendcorpus/train.py` for clarity and robustness, including passing configuration arguments explicitly. [[1]](diffhunk://#diff-e5034a2989a3f3800d404e2dbc1d06465a8f9c3f11aacd0301441727ca330abfR174-R186) [[2]](diffhunk://#diff-f4e382b1d92b08d65462634aa36d362cc9b90b33e0db1d479ebed03f94ba31f7L120-R120)

**Code Style and Assertion Formatting:**

* Standardized assertion formatting for clarity in `blendcorpus/dataset/sptoken.py`, `blendcorpus/train.py`, and other modules. [[1]](diffhunk://#diff-32bd7cda8f260fb1b4f56a407c180fde560cacc1745908d27c7d596abf4d32afL20-R23) [[2]](diffhunk://#diff-32bd7cda8f260fb1b4f56a407c180fde560cacc1745908d27c7d596abf4d32afL58-R61) [[3]](diffhunk://#diff-32bd7cda8f260fb1b4f56a407c180fde560cacc1745908d27c7d596abf4d32afL72-R75) [[4]](diffhunk://#diff-e5034a2989a3f3800d404e2dbc1d06465a8f9c3f11aacd0301441727ca330abfL685-R701)
* Minor style and logging improvements, such as switching from logger to print for stage info in pipeline parallel and updating logging import usage. [[1]](diffhunk://#diff-bb248119abb68ae0ef20da646e50666e7e1ca2957c0e576d567ad56f2a660bbdL287-R287) [[2]](diffhunk://#diff-d4bd24d89043e414d3daf556f65d92cd86eb347a9e1f2f429caae9cc6457cde6L20-R28)

**Profiling and Data Path Updates:**

* Enabled profiling and memory snapshotting in `train_configs/auroraGPT_2B.toml`, and updated data cache paths for both AuroraGPT and Llama3-70B configurations. [[1]](diffhunk://#diff-8930780283871f4ab7a72b7313c7aec6a8ba9bf4cc641a8c26aa246955f209f5L10-R13) [[2]](diffhunk://#diff-8930780283871f4ab7a72b7313c7aec6a8ba9bf4cc641a8c26aa246955f209f5L106-R106) [[3]](diffhunk://#diff-afb77ff598a535ac86c9d161d2df4ea06130b7f9779a64e27ab27bc9b32ff321L87-R89)